### PR TITLE
Allow filename as positional argument

### DIFF
--- a/sigmf_to_vrt.cpp
+++ b/sigmf_to_vrt.cpp
@@ -110,9 +110,13 @@ int main(int argc, char* argv[])
         ("port", po::value<uint16_t>(&port)->default_value(50100), "VRT ZMQ port")
         ("hwm", po::value<int>(&hwm)->default_value(10000), "VRT ZMQ HWM")
     ;
+
     // clang-format on
+    po::positional_options_description parser_positional;
+    parser_positional.add("file", -1);
+
     po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::store(po::command_line_parser(argc, argv).options(desc).positional(parser_positional).run(), vm);
     po::notify(vm);
 
     // print the help message
@@ -141,7 +145,11 @@ int main(int argc, char* argv[])
     pt::ptree root;
 
     // Load the json file in this ptree
-    pt::read_json(file, root);
+    std::string meta_filename;
+    boost::filesystem::path base_fn_fp(file);
+    base_fn_fp.replace_extension(".sigmf-meta");
+    meta_filename = base_fn_fp.string();
+    pt::read_json(meta_filename, root);
 
     rate = root.get<double>("global.core:sample_rate", 0);
     bw = root.get<double>("global.vrt:bandwidth", 0);
@@ -183,7 +191,6 @@ int main(int argc, char* argv[])
     // Open data file
 
     std::string data_filename;
-    boost::filesystem::path base_fn_fp(file);
     base_fn_fp.replace_extension(".sigmf-data");
     data_filename = base_fn_fp.string();
 


### PR DESCRIPTION
This allows to give the sigmf filename as positional argument. Also, giving the sigmf-data filename instead of the sigmf-meta filename now is allowed.